### PR TITLE
Support encode of float using float8send

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,6 @@ Encodes `jsonb` object into `bytea` string.
 
 Decodes `jsonb` object from `bytea` string.
 
-## TODO
-
-- Float/double encoding
-
 ## Sponsors
 
 Development is sponsored by [Integromat](https://www.integromat.com/en/integrations/postgres).

--- a/src/encode.sql
+++ b/src/encode.sql
@@ -61,10 +61,10 @@ begin
 		when 'number' then
 			_numeric = (_data#>>'{}')::numeric;
 			if _numeric % 1 != 0 then
-				raise exception 'Float not implemented yet.';
-			end if;
+				-- Float
+				_pack = E'\\313' || float8send(_numeric::float8);
 
-			if _numeric > 0 then
+			elsif _numeric > 0 then
 				-- Integer
 				if _numeric < 2 ^ 7 then
 					_pack = set_byte(E' '::bytea, 0, _numeric::integer);

--- a/test/encode.sql
+++ b/test/encode.sql
@@ -20,6 +20,10 @@ assert (select public.msgpack_encode('-2147483647'::jsonb)) = decode('d280000001
 assert (select public.msgpack_encode('9223372036854775807'::jsonb)) = decode('cf7fffffffffffffff', 'hex'), 'Integer #11';
 assert (select public.msgpack_encode('-9223372036854775807'::jsonb)) = decode('d38000000000000001', 'hex'), 'Integer #12';
 
+assert (select public.msgpack_encode('1.337'::jsonb) = decode('cb3ff5645a1cac0831', 'hex')), 'Double #1';
+assert (select public.msgpack_encode('0.005'::jsonb) = decode('cb3f747ae147ae147b', 'hex')), 'Double #2';
+assert (select public.msgpack_encode('-1.337'::jsonb) = decode('cbbff5645a1cac0831', 'hex')), 'Double #3';
+
 assert (select public.msgpack_encode('[]'::jsonb)) = decode('90', 'hex'), 'Array #1';
 assert (select public.msgpack_encode('[1]'::jsonb)) = decode('9101', 'hex'), 'Array #2';
 assert (select public.msgpack_encode('[1,"x"]'::jsonb)) = decode('9201a178', 'hex'), 'Array #3';


### PR DESCRIPTION
float8send doesn't seem to be documented, but it does exactly what is
needed: produces the binary encoding of a float8.